### PR TITLE
fix: gateway exception handle bug

### DIFF
--- a/lcserve/backend/gateway.py
+++ b/lcserve/backend/gateway.py
@@ -560,7 +560,7 @@ class ServingGateway(FastAPIBaseGateway):
                             if _ws_serving_error != '':
                                 print(f'Error: {_ws_serving_error}')
 
-                except WebSocketDisconnect:
+                except WebSocketDisconnect as e:
                     self.logger.info(
                         f'Client {websocket.client} disconnected from `{func.__name__}` with code {e.code} and reason {e.reason}'
                     )


### PR DESCRIPTION
This PR is to fix the bug encountered on Jina AI Cloud:

```
  File "/workdir/lcserve/backend/gateway.py", line 565, in _create_ws_route
    f'Client {websocket.client} disconnected from `{func.__name__}` with code {e.code} and reason {e.reason}'
UnboundLocalError: local variable 'e' referenced before assignment
```