### PR TITLE
fix: disallow langchain-serve in requirements.txt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'README.md'
+
+jobs:
+  commit-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.5.0
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v4
+
+  lint-flake-8:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.5.0
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.7
+      - name: Lint with flake8
+        run: |
+          pip install flake8
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --exclude .git,__pycache__,docs/source/conf.py,old,build,dist,tests/
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude .git,__pycache__,docs/source/conf.py,old,build,dist,tests/
+
+  check-black:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.5.0
+        with:
+          fetch-depth: 0
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.7
+      - id: file_changes
+        uses: Ana06/get-changed-files@v1.2
+      - name: check black
+        run: ./scripts/black.sh
+        env:
+          CHANGED_FILES: ${{ steps.file_changes.outputs.added_modified }}

--- a/lcserve/__main__.py
+++ b/lcserve/__main__.py
@@ -35,6 +35,7 @@ async def serve_on_jcloud(
     requirements: List[str] = None,
     app_id: str = None,
     version: str = 'latest',
+    platform: str = None,
     verbose: bool = False,
 ):
     from .backend.playground.utils.helper import get_random_tag
@@ -45,6 +46,7 @@ async def serve_on_jcloud(
         requirements=requirements,
         tag=tag,
         version=version,
+        platform=platform,
         verbose=verbose,
     )
     app_id, endpoint = await deploy_app_on_jcloud(
@@ -68,6 +70,7 @@ async def serve_babyagi_on_jcloud(
     requirements: List[str] = None,
     app_id: str = None,
     version: str = 'latest',
+    platform: str = None,
     verbose: bool = False,
 ):
     await serve_on_jcloud(
@@ -76,6 +79,7 @@ async def serve_babyagi_on_jcloud(
         requirements=requirements,
         app_id=app_id,
         version=version,
+        platform=platform,
         verbose=verbose,
     )
 
@@ -138,6 +142,13 @@ def local(module, port):
     show_default=False,
 )
 @click.option(
+    '--platform',
+    type=str,
+    default=None,
+    help='Platform of Docker image needed for the deployment is built on.',
+    show_default=False,
+)
+@click.option(
     '--verbose',
     is_flag=True,
     help='Verbose mode.',
@@ -145,12 +156,13 @@ def local(module, port):
 )
 @click.help_option('-h', '--help')
 @syncify
-async def jcloud(module, name, app_id, version, verbose):
+async def jcloud(module, name, app_id, version, platform, verbose):
     await serve_on_jcloud(
         module,
         name=name,
         app_id=app_id,
         version=version,
+        platform=platform,
         verbose=verbose,
     )
 
@@ -184,6 +196,13 @@ async def jcloud(module, name, app_id, version, verbose):
     show_default=False,
 )
 @click.option(
+    '--platform',
+    type=str,
+    default=None,
+    help='Platform of Docker image needed for the deployment is built on.',
+    show_default=False,
+)
+@click.option(
     '--verbose',
     is_flag=True,
     help='Verbose mode.',
@@ -191,12 +210,13 @@ async def jcloud(module, name, app_id, version, verbose):
 )
 @click.help_option('-h', '--help')
 @syncify
-async def babyagi(name, requirements, app_id, version, verbose):
+async def babyagi(name, requirements, app_id, version, platform, verbose):
     await serve_babyagi_on_jcloud(
         name=name,
         requirements=requirements,
         app_id=app_id,
         version=version,
+        platform=platform,
         verbose=verbose,
     )
 

--- a/lcserve/flow.py
+++ b/lcserve/flow.py
@@ -215,6 +215,16 @@ def push_app_to_hubble(
         with open(os.path.join(tmpdir, 'requirements.txt'), 'w') as f:
             f.write('\n'.join(requirements))
 
+    # Remove langchain-serve itself from the requirements list as it may be entered by mistake and break things
+    if os.path.exists(os.path.join(tmpdir, 'requirements.txt')):
+        with open(os.path.join(tmpdir, 'requirements.txt'), 'r') as f:
+            requirements = f.read().splitlines()
+
+        requirements = [r for r in requirements if not r.startswith("langchain-serve")]
+
+        with open(os.path.join(tmpdir, 'requirements.txt'), 'w') as f:
+            f.write('\n'.join(requirements))
+
     # Create the Dockerfile
     with open(os.path.join(tmpdir, 'Dockerfile'), 'w') as f:
         dockerfile = [
@@ -251,6 +261,9 @@ def push_app_to_hubble(
         args_list.append('--verbose')
 
     args = set_hub_push_parser().parse_args(args_list)
+
+    # This is done to make sure the image is still built for linux/amd64 when the machine that initializes the deployment uses arm64 (m chip)
+    args.platform = "linux/amd64"
 
     if hubble_exists(name):
         args.force_update = name

--- a/lcserve/flow.py
+++ b/lcserve/flow.py
@@ -168,6 +168,7 @@ def push_app_to_hubble(
     tag: str = 'latest',
     requirements: Tuple[str] = None,
     version: str = 'latest',
+    platform: str = None,
     verbose: Optional[bool] = False,
 ) -> Tuple[str, bool]:
     from hubble.executor.hubio import HubIO
@@ -262,8 +263,8 @@ def push_app_to_hubble(
 
     args = set_hub_push_parser().parse_args(args_list)
 
-    # This is done to make sure the image is still built for linux/amd64 when the machine that initializes the deployment uses arm64 (m chip)
-    args.platform = "linux/amd64"
+    if platform:
+        args.platform = platform
 
     if hubble_exists(name):
         args.force_update = name

--- a/scripts/black.sh
+++ b/scripts/black.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+pip install black==22.3.0
+arrVar=()
+echo we ignore non-*.py files
+excluded_files=(
+)
+for changed_file in $CHANGED_FILES; do
+  if [[ ${changed_file} == *.py ]] && ! [[ " ${excluded_files[@]} " =~ " ${changed_file} " ]]; then
+    echo checking ${changed_file}
+    arrVar+=(${changed_file})
+  fi
+done
+if (( ${#arrVar[@]} )); then
+  black -S --check "${arrVar[@]}"
+fi
+echo "no files left to check"
+exit 0


### PR DESCRIPTION
## Changes ##

- Fixed https://github.com/jina-ai/langchain-serve/issues/14, if for whatever reason `langchain-serve` is added to app (which could break things), we need to purge it.
-  Added `--platform` support so it will work for Mac m chip users (via using `--platform=linux/amd64`).
-  Added more steps in CI including flake8 and black lint. 

## Tests ##
Deployed an app with `python -m lcserve.__main__ deploy babyagi --requirements=jina --platform=linux/amd64` and `langchain-serve==0.03` in `requirements.txt`, the deployments purged `langchain-serve` as expected:

<img width="542" alt="Screenshot 2023-04-18 at 18 53 59" src="https://user-images.githubusercontent.com/2687065/232756082-e2ebfc15-53d5-4424-816f-1f28ce2fbebc.png">
