### PR TITLE
fix: upgrade jina version to 3.15.2, to let dependents be installed on platform Windows

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-jina==3.15.0
+jina==3.15.2
 click
 jcloud>=0.2.6
 requests


### PR DESCRIPTION
Dependents of [jina ](https://github.com/jina-ai/jina) and [langchain-serve](https://github.com/NotAndOr/jina-ai.langchain-serve) such as [LangChain-ChatGLM-Webui](https://github.com/thomas-yanxin/LangChain-ChatGLM-Webui) can [be installed on platform Windows by poetry](https://github.com/thomas-yanxin/LangChain-ChatGLM-Webui/pull/47) IFF jina version is specified as NOT elder than [3.15.2](https://github.com/jina-ai/jina/tree/v3.15.2) which comes with [jina-pull-5841](https://github.com/jina-ai/jina/pull/5841).