### PR TITLE
 build: remove pandasai to support python 3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 
 
+
 <a name=release-note-0-0-1></a>
 ## Release Note (`0.0.1`)
 
@@ -793,4 +794,30 @@
 ### 🍹 Other Improvements
 
  - [[```8f5fb3e0```](https://github.com/jina-ai/langchain-serve/commit/8f5fb3e0cc51243a9522ebfb07d208b426fc9ffe)] __-__ __version__: the next version will be 0.0.31 (*Jina Dev Bot*)
+
+<a name=release-note-0-0-32></a>
+## Release Note (`0.0.32`)
+
+> Release time: 2023-05-17 05:23:33
+
+
+
+🙇 We'd like to thank all contributors for this new release! In particular,
+ Deepankar Mahapatro,  Zac Li,  Han Xiao,  Jina Dev Bot,  🙇
+
+
+### 🆕 New Features
+
+ - [[```2f6ab699```](https://github.com/jina-ai/langchain-serve/commit/2f6ab6996c5548fee1addda5d236e7c9eb42600e)] __-__ pricing related (*Zac Li*)
+
+### 🏁 Unit Test and CICD
+
+ - [[```b46c55b1```](https://github.com/jina-ai/langchain-serve/commit/b46c55b1035a617b89f023b4f7304a76c8cf801b)] __-__ update langflow-push.yml (*Deepankar Mahapatro*)
+ - [[```76ecf1bc```](https://github.com/jina-ai/langchain-serve/commit/76ecf1bc39ab4ef4a4b3f94f30411b4b44e0b03d)] __-__ create test-push.yml (*Deepankar Mahapatro*)
+ - [[```06eccf9c```](https://github.com/jina-ai/langchain-serve/commit/06eccf9cea27bc1f3e3b0a29a54c97f6b62bdfe0)] __-__ add langflow push workflow (*Deepankar Mahapatro*)
+
+### 🍹 Other Improvements
+
+ - [[```cb028852```](https://github.com/jina-ai/langchain-serve/commit/cb028852d3ae5e6ec1ea9f9e2750663e2fe45263)] __-__ fix slack link to discord (*Han Xiao*)
+ - [[```53ccbf99```](https://github.com/jina-ai/langchain-serve/commit/53ccbf9901834ef59db0e95e2dbe09d60bbfe582)] __-__ __version__: the next version will be 0.0.32 (*Jina Dev Bot*)
 

--- a/README.md
+++ b/README.md
@@ -710,22 +710,35 @@ Applications hosted on JCloud are priced in two categories:
 
 **Example 1:**
 
-Consider a HTTP application which, in the last hour, has served requests for `10` minutes (either sequentially or concurrently). The application uses a custom config:
+Consider an HTTP application that has served requests for `10` minutes in the last hour and uses a custom config:
 ```
 instance: C4
 autoscale_min: 0
 ```
-In this case, the cost would be approximately `3.33` credits. The calculation is `20 * 10/60 + 20 * 0`, where `20` is the hourly credit rate for a `C4` instance.
+
+Total credits per hour charged would be `3.33`. The calculation is as follows:
+```
+C4 instance has an hourly credit rate of 20.
+Base credits = 0 (since `autoscale_min` is 0)
+Serving credits = 20 * 10/60 = 3.33
+Total credits per hour = 3.33
+```
 
 **Example 2:**
 
-A WebSocket application which, in the last hour, has actively connections for 20 minutes. The application uses the default configuration.
+Consider a WebSocket application that had active connections for 20 minutes in the last hour and uses the default configuration.
 ```
 instance: C3
 autoscale_min: 1
 ```
 
-The cost here would be approximately `13.33` credits. The calculation is `10 * 20/60 + 10 * 1 = 3.33`, where `10` is the hourly credit rate for a `C3` instance. 
+Total credits per hour charged would be `13.33`. The calculation is as follows:
+```
+C3 instance has an hourly credit rate of 10.
+Base credits = 10 (since `autoscale_min` is 1)
+Serving credits = 10 * 20/60 = 3.33
+Total credits per hour = 10 + 3.33 = 13.33
+```
 
 # :grey_question: Frequently Asked Questions
 

--- a/README.md
+++ b/README.md
@@ -702,9 +702,9 @@ Applications hosted on JCloud are priced in two categories:
 - You are charged for each second your application is serving requests.
 
 
-**Total credits = Base credits + Serving credits**
+**Total credits charged = Base credits + Serving credits**
 
-And price per credit is €0.005 as per the [Jina AI Cloud Pricing](https://docs.jina.ai/concepts/jcloud/configuration/#cpu-tiers).
+[Jina AI Cloud](https://cloud.jina.ai/pricing) defines each credit as €0.005.
 
 ### Examples
 

--- a/lcserve/__init__.py
+++ b/lcserve/__init__.py
@@ -14,4 +14,4 @@ _ignore_warnings()
 
 from .backend import serving, download_df, upload_df
 
-__version__ = '0.0.32'
+__version__ = '0.0.33'

--- a/lcserve/apps/pandas_ai/api.py
+++ b/lcserve/apps/pandas_ai/api.py
@@ -5,8 +5,12 @@ import nest_asyncio
 from lcserve import serving, download_df
 from fastapi import WebSocket
 
-from pandasai import PandasAI
-from pandasai.llm.openai import OpenAI
+try:
+    from pandasai import PandasAI
+    from pandasai.llm.openai import OpenAI
+except ImportError:
+    print("PandasAI not installed. Install with `pip install pandasai`.")
+    raise
 
 nest_asyncio.apply()
 

--- a/lcserve/apps/pandas_ai/api.py
+++ b/lcserve/apps/pandas_ai/api.py
@@ -8,7 +8,7 @@ from fastapi import WebSocket
 try:
     from pandasai import PandasAI
     from pandasai.llm.openai import OpenAI
-except ImportError:
+except (ImportError, ModuleNotFoundError):
     print("PandasAI not installed. Install with `pip install pandasai`.")
     raise
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,4 @@ langchain
 jina-hubble-sdk
 nest-asyncio
 textual
-pandasai
 toml


### PR DESCRIPTION
Since `panadasai` is only supported for python >=3.9, this PR removes the mandatory dependency from requirements.txt. This was fixing the langchain-serve version to be 0.22 for python >=3.9.