### PR TITLE
build: remove pandasai to support python 3.8

### DIFF
--- a/lcserve/apps/pandas_ai/api.py
+++ b/lcserve/apps/pandas_ai/api.py
@@ -5,8 +5,12 @@ import nest_asyncio
 from lcserve import serving, download_df
 from fastapi import WebSocket
 
-from pandasai import PandasAI
-from pandasai.llm.openai import OpenAI
+try:
+    from pandasai import PandasAI
+    from pandasai.llm.openai import OpenAI
+except (ImportError, ModuleNotFoundError):
+    print("PandasAI not installed. Please install using `pip install pandasai`")
+    exit(1)
 
 nest_asyncio.apply()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,4 @@ langchain
 jina-hubble-sdk
 nest-asyncio
 textual
-pandasai
 toml


### PR DESCRIPTION
Since `panadasai` is only supported for python >=3.9, this PR removes the mandatory dependency from requirements.txt. This was fixing the langchain-serve version to be 0.22 for python >=3.9.