### PR TITLE
feat: private executor push

### DIFF
--- a/lcserve/__main__.py
+++ b/lcserve/__main__.py
@@ -25,7 +25,6 @@ from .flow import (
     resolve_jcloud_config,
     syncify,
     update_requirements,
-    remove_prefix,
     get_uri,
 )
 from .utils import validate_jcloud_config_callback
@@ -48,28 +47,6 @@ def serve_locally(
         f.block()
 
 
-def _push_app_to_hubble(
-    module_dir: str,
-    image_name: str = None,
-    tag: str = None,
-    requirements: List[str] = None,
-    version: str = 'latest',
-    platform: str = None,
-    verbose: bool = False,
-):
-    from .flow import push_app_to_hubble
-
-    return push_app_to_hubble(
-        module_dir=module_dir,
-        image_name=image_name,
-        tag=tag,
-        requirements=requirements,
-        version=version,
-        platform=platform,
-        verbose=verbose,
-    )
-
-
 async def serve_on_jcloud(
     module_str: str = None,
     fastapi_app_str: str = None,
@@ -84,22 +61,23 @@ async def serve_on_jcloud(
     config: str = None,
     verbose: bool = False,
     cors: bool = True,
-    lc_serve_app: bool = False,
+    lcserve_app: bool = False,
 ) -> str:
+    from .flow import push_app_to_hubble
     from .backend.playground.utils.helper import get_random_tag
 
     module_dir, is_websocket = get_module_dir(
         module_str=module_str,
         fastapi_app_str=fastapi_app_str,
         app_dir=app_dir,
-        lc_serve_app=lc_serve_app,
+        lcserve_app=lcserve_app,
     )
     config = resolve_jcloud_config(config, module_dir)
 
     if uses is not None:
         gateway_id = uses
     else:
-        gateway_id = _push_app_to_hubble(
+        gateway_id = push_app_to_hubble(
             module_dir=module_dir,
             requirements=requirements,
             tag=get_random_tag(),
@@ -121,7 +99,7 @@ async def serve_on_jcloud(
             is_websocket=is_websocket,
             jcloud_config_path=config,
             cors=cors,
-            lc_serve_app=lc_serve_app,
+            lcserve_app=lcserve_app,
         ),
         app_id=app_id,
         verbose=verbose,
@@ -160,7 +138,7 @@ async def serve_babyagi_on_jcloud(
         config=config,
         verbose=verbose,
         cors=cors,
-        lc_serve_app=True,
+        lcserve_app=True,
     )
 
 
@@ -194,7 +172,7 @@ async def serve_autogpt_on_jcloud(
         config=config,
         verbose=verbose,
         cors=cors,
-        lc_serve_app=True,
+        lcserve_app=True,
     )
 
 
@@ -221,7 +199,7 @@ async def serve_pdf_qna_on_jcloud(
         config=config,
         verbose=verbose,
         cors=cors,
-        lc_serve_app=True,
+        lcserve_app=True,
     )
 
 
@@ -248,7 +226,7 @@ async def serve_pandas_ai_on_jcloud(
         config=config,
         verbose=verbose,
         cors=cors,
-        lc_serve_app=True,
+        lcserve_app=True,
     )
 
 
@@ -420,12 +398,14 @@ def push(
     version,
     verbose,
 ):
+    from .flow import push_app_to_hubble
+
     module_dir, _ = get_module_dir(
         module_str=module_str,
         fastapi_app_str=app,
         app_dir=app_dir,
     )
-    gateway_id = _push_app_to_hubble(
+    gateway_id = push_app_to_hubble(
         module_dir=module_dir,
         image_name=image_name,
         tag=image_tag,

--- a/lcserve/__main__.py
+++ b/lcserve/__main__.py
@@ -59,7 +59,7 @@ def _push_app_to_hubble(
 ):
     from .flow import push_app_to_hubble
 
-    gateway_id = push_app_to_hubble(
+    return push_app_to_hubble(
         module_dir=module_dir,
         image_name=image_name,
         tag=tag,
@@ -68,7 +68,6 @@ def _push_app_to_hubble(
         platform=platform,
         verbose=verbose,
     )
-    return gateway_id
 
 
 async def serve_on_jcloud(
@@ -85,6 +84,7 @@ async def serve_on_jcloud(
     config: str = None,
     verbose: bool = False,
     cors: bool = True,
+    lc_serve_app: bool = False,
 ) -> str:
     from .backend.playground.utils.helper import get_random_tag
 
@@ -92,6 +92,7 @@ async def serve_on_jcloud(
         module_str=module_str,
         fastapi_app_str=fastapi_app_str,
         app_dir=app_dir,
+        lc_serve_app=lc_serve_app,
     )
     config = resolve_jcloud_config(config, module_dir)
 
@@ -120,6 +121,7 @@ async def serve_on_jcloud(
             is_websocket=is_websocket,
             jcloud_config_path=config,
             cors=cors,
+            lc_serve_app=lc_serve_app,
         ),
         app_id=app_id,
         verbose=verbose,
@@ -158,6 +160,7 @@ async def serve_babyagi_on_jcloud(
         config=config,
         verbose=verbose,
         cors=cors,
+        lc_serve_app=True,
     )
 
 
@@ -191,6 +194,7 @@ async def serve_autogpt_on_jcloud(
         config=config,
         verbose=verbose,
         cors=cors,
+        lc_serve_app=True,
     )
 
 
@@ -217,6 +221,7 @@ async def serve_pdf_qna_on_jcloud(
         config=config,
         verbose=verbose,
         cors=cors,
+        lc_serve_app=True,
     )
 
 
@@ -243,6 +248,7 @@ async def serve_pandas_ai_on_jcloud(
         config=config,
         verbose=verbose,
         cors=cors,
+        lc_serve_app=True,
     )
 
 

--- a/lcserve/apps/autogpt/app.py
+++ b/lcserve/apps/autogpt/app.py
@@ -9,7 +9,10 @@ from langchain.chat_models import ChatOpenAI
 
 from lcserve import serving
 
-from .helper import CustomTool, PredefinedTools, get_agent, get_tools
+try:
+    from .helper import CustomTool, PredefinedTools, get_agent, get_tools
+except ImportError:
+    from helper import CustomTool, PredefinedTools, get_agent, get_tools
 
 
 @serving(websocket=True)

--- a/lcserve/backend/gateway.py
+++ b/lcserve/backend/gateway.py
@@ -265,12 +265,14 @@ class ServingGateway(FastAPIBaseGateway):
         self,
         modules: Tuple[str] = None,
         fastapi_app_str: str = None,
+        lc_serve_app: bool = False,
         *args,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
         self._modules = modules
         self._fastapi_app_str = fastapi_app_str
+        self._lc_serve_app = lc_serve_app
         self._fix_sys_path()
         self._init_fastapi_app()
         self._setup_metrics()
@@ -312,10 +314,11 @@ class ServingGateway(FastAPIBaseGateway):
             # This is where the app code is mounted in the container
             sys.path.append(APPDIR)
 
-        # register all predefined apps to sys.path if they exist
-        if os.path.exists(os.path.join(APPDIR, 'lcserve', 'apps')):
-            for app in os.listdir(os.path.join(APPDIR, 'lcserve', 'apps')):
-                sys.path.append(os.path.join(APPDIR, 'lcserve', 'apps', app))
+        if self._lc_serve_app:
+            # register all predefined apps to sys.path if they exist
+            if os.path.exists(os.path.join(APPDIR, 'lcserve', 'apps')):
+                for app in os.listdir(os.path.join(APPDIR, 'lcserve', 'apps')):
+                    sys.path.append(os.path.join(APPDIR, 'lcserve', 'apps', app))
 
     def _setup_metrics(self):
         from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor

--- a/lcserve/backend/gateway.py
+++ b/lcserve/backend/gateway.py
@@ -265,14 +265,14 @@ class ServingGateway(FastAPIBaseGateway):
         self,
         modules: Tuple[str] = None,
         fastapi_app_str: str = None,
-        lc_serve_app: bool = False,
+        lcserve_app: bool = False,
         *args,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
         self._modules = modules
         self._fastapi_app_str = fastapi_app_str
-        self._lc_serve_app = lc_serve_app
+        self._lcserve_app = lcserve_app
         self._fix_sys_path()
         self._init_fastapi_app()
         self._setup_metrics()
@@ -314,7 +314,7 @@ class ServingGateway(FastAPIBaseGateway):
             # This is where the app code is mounted in the container
             sys.path.append(APPDIR)
 
-        if self._lc_serve_app:
+        if self._lcserve_app:
             # register all predefined apps to sys.path if they exist
             if os.path.exists(os.path.join(APPDIR, 'lcserve', 'apps')):
                 for app in os.listdir(os.path.join(APPDIR, 'lcserve', 'apps')):

--- a/lcserve/flow.py
+++ b/lcserve/flow.py
@@ -162,11 +162,11 @@ def hubble_exists(name: str, secret: Optional[str] = None) -> bool:
     )
 
 
-def _add_to_path(lc_serve_app: bool = False):
+def _add_to_path(lcserve_app: bool = False):
     # add current directory to the beginning of the path to prioritize local imports
     sys.path.insert(0, os.getcwd())
 
-    if lc_serve_app:
+    if lcserve_app:
         # get all directories in the apps folder and add them to the path
         for app in os.listdir(os.path.join(os.path.dirname(__file__), 'apps')):
             if os.path.isdir(os.path.join(os.path.dirname(__file__), 'apps', app)):
@@ -242,9 +242,9 @@ def get_module_dir(
     module_str: str = None, 
     fastapi_app_str: str = None, 
     app_dir: str = None, 
-    lc_serve_app: bool = False,
+    lcserve_app: bool = False,
 ) -> Tuple[str, bool]:
-    _add_to_path(lc_serve_app=lc_serve_app)
+    _add_to_path(lcserve_app=lcserve_app)
 
     if module_str is not None:
         _module = _load_module_from_str(module_str)
@@ -664,7 +664,7 @@ def get_flow_dict(
     is_websocket: bool = False,
     jcloud_config_path: str = None,
     cors: bool = True,
-    lc_serve_app: bool = False,
+    lcserve_app: bool = False,
 ) -> Dict:
     if jcloud:
         jcloud_config = get_jcloud_config(
@@ -680,7 +680,7 @@ def get_flow_dict(
             'uses_with': {
                 'modules': [module_str] if module_str else [],
                 'fastapi_app_str': fastapi_app_str or '',
-                'lc_serve_app': lc_serve_app,
+                'lcserve_app': lcserve_app,
             },
             'port': [port],
             'protocol': ['websocket'] if is_websocket else ['http'],
@@ -712,7 +712,7 @@ def get_flow_yaml(
     is_websocket: bool = False,
     cors: bool = True,
     jcloud_config_path: str = None,
-    lc_serve_app: bool = False,
+    lcserve_app: bool = False,
 ) -> str:
     return yaml.safe_dump(
         get_flow_dict(
@@ -724,7 +724,7 @@ def get_flow_yaml(
             cors=cors,
             jcloud=jcloud,
             jcloud_config_path=jcloud_config_path,
-            lc_serve_app=lc_serve_app,
+            lcserve_app=lcserve_app,
         ),
         sort_keys=False,
     )

--- a/tests/unit/test_flow.py
+++ b/tests/unit/test_flow.py
@@ -24,6 +24,7 @@ flow_dict_template = {
         "uses_with": {
             "modules": ["dummy"],
             "fastapi_app_str": "dummy",
+            "lcserve_app": False,
         },
         "port": [8080],
         "protocol": [None],
@@ -105,6 +106,7 @@ def test_get_flow_dict_for_local():
             "uses_with": {
                 "modules": ["dummy"],
                 "fastapi_app_str": "dummy",
+                "lcserve_app": False, 
             },
             "port": [8080],
             "protocol": ["http"],


### PR DESCRIPTION
1. Push Gateway as `private` - Fixes #81 
2. Hide messages from `hubble` during `push` and `jcloud` during `deploy` when `--verbose` is not passed - Fixes #62 
    
    **No verbose**
    ![image](https://github.com/jina-ai/langchain-serve/assets/9050737/e43834dc-529b-4947-b087-1b353075ea46)

    **Verbose**
    ![image](https://github.com/jina-ai/langchain-serve/assets/9050737/10644b6a-573a-4f75-a41e-ff96bb81aed4)
